### PR TITLE
Int64 unpack fixes

### DIFF
--- a/lib/binarypack.js
+++ b/lib/binarypack.js
@@ -113,7 +113,7 @@ BinaryPack.Unpacker.prototype.readUInt64 = function(){
 }
 
 BinaryPack.Unpacker.prototype.readInt64 = function(){
-  var uint64 = this.readInt64();
+  var uint64 = this.readUInt64();
   return (uint64 < Math.pow(2, 63) ) ? uint64 : uint64 - Math.pow(2, 64);
 }
 

--- a/lib/binarypack.js
+++ b/lib/binarypack.js
@@ -102,14 +102,14 @@ BinaryPack.Unpacker.prototype.unpack = function(){
 }
 BinaryPack.Unpacker.prototype.readUInt64 = function(){
   var bytes = this.cursor.slice(8);
-  return ((((((bytes[0]  * 256 +
-               bytes[1]) * 256 +
-               bytes[2]) * 256 +
-               bytes[3]) * 256 +
-               bytes[4]) * 256 +
-               bytes[5]) * 256 +
-               bytes[6]) * 256 +
-               bytes[7];
+  return ((((((bytes.buffer[0]  * 256 +
+               bytes.buffer[1]) * 256 +
+               bytes.buffer[2]) * 256 +
+               bytes.buffer[3]) * 256 +
+               bytes.buffer[4]) * 256 +
+               bytes.buffer[5]) * 256 +
+               bytes.buffer[6]) * 256 +
+               bytes.buffer[7];
 }
 
 BinaryPack.Unpacker.prototype.readInt64 = function(){

--- a/package.json
+++ b/package.json
@@ -14,6 +14,12 @@
   },
   "dependencies" : {
     "buffercursor" : ">=0.0.3"
+  },
+  "devDependencies": {
+    "nodeunit" : ">=0.8.0"
+  },
+  "scripts": {
+    "test": "nodeunit test/binarypack.nodeunit.js"
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=0.6.0"
   },
   "dependencies" : {
-    "buffercursor" : ">=0.0.3"
+    "buffercursor" : "git+https://github.com/loughmiller/node-buffercursor.git#master"
   },
   "devDependencies": {
     "nodeunit" : ">=0.8.0"

--- a/test/binarypack.nodeunit.js
+++ b/test/binarypack.nodeunit.js
@@ -1,0 +1,77 @@
+/*jslint node: true */
+
+"use strict";
+
+var binarypack = require('../lib/binarypack.js');
+
+function testPackUnpack(test, data) {
+    console.log('packing: ', data);
+    var buffer = binarypack.pack(data);
+    console.log('unpacking');
+    test.strictEqual(binarypack.unpack(buffer), data);
+}
+
+
+exports.integers = {
+    testInt32 : function (test) {
+
+        var i,
+            int32Max = Math.pow(2, 31) - 1;
+
+        for (i=1; i<=int32Max; i*=2) {
+
+            // test positive
+            testPackUnpack(test, i);
+
+            // test negative
+            testPackUnpack(test, i * -1);
+
+            // test + 1
+            testPackUnpack(test, i + 1);
+
+            // test - 1
+            testPackUnpack(test, i - 1);
+
+            // test negative + 1
+            testPackUnpack(test, (i + 1) * -1);
+
+            // test negative - 1
+            testPackUnpack(test, (i - 1) * -1);
+        }
+
+        testPackUnpack(test, int32Max);
+
+        testPackUnpack(test, int32Max * -1);
+
+        test.done();
+    },
+
+    testUInt32 : function (test) {
+
+        testPackUnpack(test, Math.pow(2, 31));
+
+        testPackUnpack(test, Math.pow(2, 32) - 1);
+
+        test.done();
+    },
+
+    testInt64 : function (test) {
+        testPackUnpack(test, Math.pow(2, 31) * -1);
+
+        testPackUnpack(test, Math.pow(2, 32));
+
+        testPackUnpack(test, Math.pow(2, 32) * -1);
+
+        testPackUnpack(test, Math.pow(2, 48));
+
+        testPackUnpack(test, Math.pow(2, 48) * -1);
+
+        // largest integer available in javascript
+        testPackUnpack(test, Math.pow(2, 53));
+
+        testPackUnpack(test, Math.pow(2, 53) * -1);
+
+        test.done();
+    }
+
+};


### PR DESCRIPTION
Added unit tests to reproduce the issues, as well as fixes.  The unit tests will not pass without a simple fix to BufferCursor that I also submitted.  The unit tests for integers could probably be improved, but this is a reasonable start.
